### PR TITLE
Add tika to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ beautifulsoup4 == 4.9.3
 nltk == 3.5
 pandas == 1.2.3
 requests == 2.24.0
+tika == 1.24
 torch == 1.8.1
 tqdm == 4.55.1
 transformers == 4.6.1


### PR DESCRIPTION
When I tried following the instructions in README, python errored as it was missing `tika`.

Version here is latest.